### PR TITLE
Add edit/delete for history and presets, add prompt preview to history

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -107,6 +107,13 @@ def get_generation(gen_id: int) -> dict | None:
     return dict(row) if row else None
 
 
+def delete_generation(gen_id: int) -> None:
+    conn = get_connection()
+    conn.execute("DELETE FROM generations WHERE id = ?", (gen_id,))
+    conn.commit()
+    conn.close()
+
+
 def get_projects() -> list[str]:
     conn = get_connection()
     rows = conn.execute(

--- a/src/presets.py
+++ b/src/presets.py
@@ -46,6 +46,21 @@ def save_preset(name: str, style_prompt: str, description: str = "") -> None:
     _write_presets(path, presets)
 
 
+def update_preset(name: str, style_prompt: str, description: str = "") -> None:
+    path = _presets_path()
+    if not path.exists():
+        raise ValueError(f"No preset named '{name}' found.")
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    presets = data.get("presets", [])
+    for p in presets:
+        if p["name"] == name:
+            p["style_prompt"] = style_prompt
+            p["description"] = description or ""
+            _write_presets(path, presets)
+            return
+    raise ValueError(f"No preset named '{name}' found.")
+
+
 def delete_preset(name: str) -> None:
     path = _presets_path()
     if not path.exists():

--- a/src/ui/history_tab.py
+++ b/src/ui/history_tab.py
@@ -10,6 +10,8 @@ from src import database as db
 from src.generator import PROVIDERS
 from src.storage import load_image_bytes
 
+_PROMPT_PREVIEW_LEN = 40
+
 
 def _reuse_generation_inputs(generation: dict) -> None:
     st.session_state.rerun_base_prompt = generation["base_prompt"]
@@ -42,7 +44,9 @@ def render_history_tab() -> None:
     st.caption(f"{len(generations)} generation(s) found.")
     for generation in generations:
         label = generation.get("title") or f"Generation #{generation['id']}"
-        with st.expander(f"**{label}** — {generation['created_at'][:19]} | {generation['provider']}"):
+        raw_prompt = generation.get("base_prompt") or ""
+        prompt_preview = raw_prompt[:_PROMPT_PREVIEW_LEN] + ("…" if len(raw_prompt) > _PROMPT_PREVIEW_LEN else "")
+        with st.expander(f"**{label}** — {generation['created_at'][:19]} | {generation['provider']} | {prompt_preview}"):
             c_img, c_detail = st.columns([2, 3])
             with c_img:
                 image_bytes = load_image_bytes(generation["output_path"] or "")
@@ -77,5 +81,11 @@ def render_history_tab() -> None:
                     except (json.JSONDecodeError, TypeError):
                         pass
 
-                if st.button("Reuse prompt", key=f"rerun_{generation['id']}"):
-                    _reuse_generation_inputs(generation)
+                btn_col1, btn_col2 = st.columns([1, 1])
+                with btn_col1:
+                    if st.button("Reuse prompt", key=f"rerun_{generation['id']}"):
+                        _reuse_generation_inputs(generation)
+                with btn_col2:
+                    if st.button("Delete", key=f"del_gen_{generation['id']}", type="secondary"):
+                        db.delete_generation(generation["id"])
+                        st.rerun()

--- a/src/ui/presets_tab.py
+++ b/src/ui/presets_tab.py
@@ -48,11 +48,58 @@ def render_presets_tab() -> None:
         st.info("No presets yet.")
         return
 
+    editing_key = "editing_preset"
+    if editing_key not in st.session_state:
+        st.session_state[editing_key] = None
+
     for preset in presets:
         with st.expander(f"**{preset['name']}**"):
-            if preset.get("description"):
-                st.markdown(f"*{preset['description']}*")
-            st.code(preset["style_prompt"])
-            if st.button("Delete preset", key=f"del_preset_{preset['name']}"):
-                preset_store.delete_preset(preset["name"])
-                st.rerun()
+            if st.session_state[editing_key] == preset["name"]:
+                # Edit form
+                with st.form(key=f"edit_preset_form_{preset['name']}"):
+                    new_description = st.text_input(
+                        "Description",
+                        value=preset.get("description", ""),
+                    )
+                    new_style = st.text_area(
+                        "Style prompt",
+                        value=preset["style_prompt"],
+                        height=80,
+                    )
+                    save_col, cancel_col = st.columns([1, 1])
+                    with save_col:
+                        save_clicked = st.form_submit_button("Save changes")
+                    with cancel_col:
+                        cancel_clicked = st.form_submit_button("Cancel")
+
+                if save_clicked:
+                    if not new_style.strip():
+                        st.error("Style prompt is required.")
+                    else:
+                        try:
+                            preset_store.update_preset(
+                                name=preset["name"],
+                                style_prompt=new_style.strip(),
+                                description=new_description.strip(),
+                            )
+                            st.session_state[editing_key] = None
+                            st.rerun()
+                        except Exception as exc:
+                            st.error(f"Could not update preset: {exc}")
+                elif cancel_clicked:
+                    st.session_state[editing_key] = None
+                    st.rerun()
+            else:
+                # Read view
+                if preset.get("description"):
+                    st.markdown(f"*{preset['description']}*")
+                st.code(preset["style_prompt"])
+                btn_col1, btn_col2 = st.columns([1, 1])
+                with btn_col1:
+                    if st.button("Edit preset", key=f"edit_preset_{preset['name']}"):
+                        st.session_state[editing_key] = preset["name"]
+                        st.rerun()
+                with btn_col2:
+                    if st.button("Delete preset", key=f"del_preset_{preset['name']}"):
+                        preset_store.delete_preset(preset["name"])
+                        st.rerun()

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -29,6 +29,19 @@ class PresetStoreTests(unittest.TestCase):
             presets.get_presets(),
         )
 
+    def test_update_preset_changes_style_and_description(self):
+        presets.save_preset("Clean", "Minimal product shot", description="Old desc")
+        presets.update_preset("Clean", "New style prompt", description="New desc")
+
+        updated = next(p for p in presets.get_presets() if p["name"] == "Clean")
+        self.assertEqual(updated["style_prompt"], "New style prompt")
+        self.assertEqual(updated["description"], "New desc")
+
+    def test_update_preset_raises_for_missing_preset(self):
+        presets.save_preset("Clean", "Minimal product shot")
+        with self.assertRaises(ValueError):
+            presets.update_preset("NonExistent", "style")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- database.py: add delete_generation()
- presets.py: add update_preset()
- history_tab: show first 40 chars of base prompt in expander label; add Delete button per generation
- presets_tab: add inline Edit form per preset (session-state-driven); keep existing Delete button
- tests/test_presets: cover update_preset success and missing-preset error paths