### PR TITLE
Extend session TTL to 30 days and refresh cookie on each valid visit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,9 @@ GOOGLE_ALLOWED_DOMAIN=mycompany.com
 # (Optional) Comma-separated list of allowed email addresses, e.g. alice@gmail.com,bob@example.com
 GOOGLE_ALLOWED_EMAILS=alice@gmail.com,bob@example.com
 
+# (Optional) How long a login session persists in days. Defaults to 30.
+# SESSION_TTL_DAYS=30
+
 # --- Storage paths (defaults write to local data/ dir; override for Railway volumes) ---
 # DB_PATH=/data/db.sqlite3
 # STORAGE_DIR=/data/images

--- a/src/auth.py
+++ b/src/auth.py
@@ -29,7 +29,8 @@ SCOPES = [
 ]
 
 _COOKIE_NAME = "auth_session"
-_SESSION_TTL = 7 * 24 * 3600   # 7 days
+_SESSION_TTL_DAYS_DEFAULT = 30
+_SESSION_TTL = int(os.environ.get("SESSION_TTL_DAYS", _SESSION_TTL_DAYS_DEFAULT)) * 24 * 3600
 _STATE_TTL = 900                # 15 minutes
 
 
@@ -280,6 +281,9 @@ def require_auth(cookie_manager) -> None:
         user = _lookup_session(token)
         if user:
             st.session_state["_auth_user"] = user
+            # Refresh the cookie on each valid visit so the session window slides
+            # forward and active users aren't forced to re-authenticate.
+            cookie_manager.set(_COOKIE_NAME, token, max_age=_SESSION_TTL)
             return
 
     # 4. Show sign-in page


### PR DESCRIPTION
- Change _SESSION_TTL from 7 days to 30 days (default)
- Read SESSION_TTL_DAYS env var so duration is configurable
- Refresh the browser cookie on each authenticated visit to implement a sliding window — active users won't be unexpectedly logged out
- Document SESSION_TTL_DAYS in .env.example

Closes #20