### PR TITLE
feat: add dark/light mode toggle with cookie persistence

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,2 @@
+[theme]
+base = "light"

--- a/app.py
+++ b/app.py
@@ -15,6 +15,7 @@ from src.ui.history_tab import render_history_tab
 from src.ui.presets_tab import render_presets_tab
 from src.ui.references_tab import render_references_tab
 from src.ui.sidebar import render_sidebar
+from src.theme import apply_theme, init_theme
 
 
 def _default_session_state(key: str, value) -> None:
@@ -49,6 +50,8 @@ st.markdown(
 
 _cookie_manager = CookieManager(key="nano_banana_auth")
 require_auth(_cookie_manager)
+init_theme(_cookie_manager)
+apply_theme()
 db.init_db()
 _init_session_state()
 

--- a/src/theme.py
+++ b/src/theme.py
@@ -1,0 +1,198 @@
+"""Dark/light mode theme management."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import streamlit as st
+
+_COOKIE_NAME = "theme_preference"
+_DEFAULT_THEME = "light"
+
+_DARK_CSS = """
+<style>
+/* ============================================================
+   DARK MODE — Streamlit theme overrides
+   ============================================================ */
+
+/* Root + main backgrounds */
+.stApp,
+[data-testid="stApp"],
+[data-testid="stAppViewContainer"],
+[data-testid="stAppViewBlockContainer"] {
+    background-color: #0e1117 !important;
+}
+
+/* Header */
+[data-testid="stHeader"] {
+    background-color: rgba(14, 17, 23, 0.95) !important;
+    border-bottom: 1px solid #2d2d3a !important;
+}
+
+/* Sidebar */
+[data-testid="stSidebar"],
+[data-testid="stSidebar"] > div:first-child {
+    background-color: #262730 !important;
+}
+
+/* Main block container */
+[data-testid="block-container"],
+.block-container {
+    background-color: #0e1117 !important;
+}
+
+/* General text */
+p, span, label, h1, h2, h3, h4, h5, h6, li {
+    color: #fafafa !important;
+}
+[data-testid="stMarkdownContainer"] p,
+[data-testid="stMarkdownContainer"] span,
+[data-testid="stMarkdownContainer"] div {
+    color: #fafafa !important;
+}
+.stCaption, [data-testid="stCaptionContainer"] {
+    color: #b0b0b0 !important;
+}
+
+/* Text inputs and text areas */
+[data-baseweb="input"],
+[data-baseweb="textarea"] {
+    background-color: #262730 !important;
+    border-color: #4a4a5a !important;
+}
+[data-baseweb="input"] input,
+[data-baseweb="textarea"] textarea,
+input[type="text"],
+input[type="email"],
+input[type="password"],
+input[type="number"],
+input[type="search"],
+textarea {
+    background-color: #262730 !important;
+    color: #fafafa !important;
+    border-color: #4a4a5a !important;
+    caret-color: #fafafa !important;
+}
+
+/* Select / dropdown trigger */
+[data-baseweb="select"] > div:first-child,
+[data-baseweb="select"] [role="combobox"] {
+    background-color: #262730 !important;
+    color: #fafafa !important;
+    border-color: #4a4a5a !important;
+}
+/* Dropdown option list */
+[data-baseweb="popover"] [role="listbox"],
+[data-baseweb="menu"] {
+    background-color: #262730 !important;
+}
+[data-baseweb="menu"] [role="option"],
+[data-baseweb="menu"] li {
+    background-color: #262730 !important;
+    color: #fafafa !important;
+}
+[data-baseweb="menu"] [role="option"]:hover,
+[data-baseweb="menu"] li:hover {
+    background-color: #3a3a4a !important;
+}
+
+/* Tabs */
+[data-baseweb="tab-list"] {
+    background-color: #0e1117 !important;
+    border-bottom-color: #2d2d3a !important;
+}
+[data-baseweb="tab"] {
+    background-color: transparent !important;
+    color: #c0c0c0 !important;
+}
+[data-baseweb="tab"][aria-selected="true"] {
+    color: #ff4b4b !important;
+    background-color: transparent !important;
+}
+[data-baseweb="tab-highlight"] {
+    background-color: #ff4b4b !important;
+}
+[data-baseweb="tab-border"] {
+    background-color: #2d2d3a !important;
+}
+
+/* Buttons (secondary / default) */
+[data-testid="stBaseButton-secondary"],
+button[kind="secondary"] {
+    background-color: #262730 !important;
+    color: #fafafa !important;
+    border-color: #4a4a5a !important;
+}
+[data-testid="stBaseButton-secondary"]:hover,
+button[kind="secondary"]:hover {
+    background-color: #3a3a4a !important;
+    border-color: #6a6a7a !important;
+}
+
+/* Dividers */
+hr {
+    border-color: #2d2d3a !important;
+}
+
+/* Expanders */
+[data-testid="stExpander"] {
+    background-color: #1a1c24 !important;
+    border-color: #2d2d3a !important;
+}
+[data-testid="stExpander"] summary span {
+    color: #fafafa !important;
+}
+
+/* Alert boxes */
+[data-testid="stAlert"] {
+    background-color: #1a1c24 !important;
+    border-color: #2d2d3a !important;
+}
+[data-testid="stAlert"] p {
+    color: #fafafa !important;
+}
+
+/* Code blocks */
+code, pre {
+    background-color: #1a1c24 !important;
+    color: #e0e0e0 !important;
+}
+
+/* Scrollbars */
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: #1a1c24; }
+::-webkit-scrollbar-thumb { background: #4a4a5a; border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: #6a6a7a; }
+</style>
+"""
+
+
+def init_theme(cookie_manager) -> None:
+    """Initialize theme from cookie or fall back to the default.
+
+    Must be called once near the top of app.py, after the cookie manager
+    is ready but before ``apply_theme``.
+    """
+    if "theme" not in st.session_state:
+        saved = cookie_manager.get(_COOKIE_NAME)
+        st.session_state["theme"] = saved if saved in ("light", "dark") else _DEFAULT_THEME
+
+
+def apply_theme() -> None:
+    """Inject CSS for the active theme.
+
+    Must be called on every render (i.e., at the top level of app.py) so
+    the styles are present regardless of which tab the user is viewing.
+    """
+    if st.session_state.get("theme") == "dark":
+        st.markdown(_DARK_CSS, unsafe_allow_html=True)
+
+
+def toggle_theme(cookie_manager) -> None:
+    """Flip the active theme and persist the choice to a cookie."""
+    current = st.session_state.get("theme", _DEFAULT_THEME)
+    new_theme = "dark" if current == "light" else "light"
+    st.session_state["theme"] = new_theme
+    expires_at = datetime.now() + timedelta(days=365)
+    cookie_manager.set(_COOKIE_NAME, new_theme, expires_at=expires_at)
+    st.rerun()

--- a/src/ui/sidebar.py
+++ b/src/ui/sidebar.py
@@ -9,6 +9,7 @@ import streamlit as st
 
 from src.auth import get_user, is_configured, logout
 from src.generator import PROVIDERS, get_provider_api_key
+from src.theme import toggle_theme
 
 
 @dataclass
@@ -66,6 +67,12 @@ def render_sidebar(cookie_manager) -> SidebarConfig:
             if model == "dall-e-3":
                 settings["quality"] = st.selectbox("Quality", ["standard", "hd"])
                 settings["style"] = st.selectbox("Style", ["vivid", "natural"])
+
+        st.divider()
+        theme = st.session_state.get("theme", "light")
+        label = "☀️ Light mode" if theme == "dark" else "🌙 Dark mode"
+        if st.button(label, width="stretch"):
+            toggle_theme(cookie_manager)
 
     return SidebarConfig(
         provider=provider,


### PR DESCRIPTION
- Add src/theme.py with CSS injection for dark mode, init_theme() to load preference from cookie on startup, apply_theme() to inject CSS on every render, and toggle_theme() to flip and persist the choice.
- Add .streamlit/config.toml pinning the base Streamlit theme to light so the starting state is always consistent.
- Add a toggle button at the bottom of the sidebar (🌙 Dark mode / ☀️ Light mode) that calls toggle_theme() and triggers a rerun.
- Wire init_theme() and apply_theme() into app.py so the preference is restored from the cookie and the CSS is applied on every page load.

Closes #30