### PR TITLE
fix: patch genai_types in description service tests

### DIFF
--- a/tests/test_description_service.py
+++ b/tests/test_description_service.py
@@ -21,7 +21,8 @@ def test_returns_stripped_text_on_success():
     mock_genai = MagicMock()
     mock_genai.Client.return_value = mock_client
 
-    with patch("src.services.description_service.genai", mock_genai):
+    with patch("src.services.description_service.genai", mock_genai), \
+         patch("src.services.description_service.genai_types", MagicMock()):
         result = generate_short_description("A banana", "test-key")
 
     assert result == "Yellow banana on wooden table"
@@ -47,7 +48,8 @@ def test_strips_trailing_period():
     mock_genai = MagicMock()
     mock_genai.Client.return_value = mock_client
 
-    with patch("src.services.description_service.genai", mock_genai):
+    with patch("src.services.description_service.genai", mock_genai), \
+         patch("src.services.description_service.genai_types", MagicMock()):
         result = generate_short_description("A banana", "test-key")
 
     assert result == "Yellow banana on wooden table"


### PR DESCRIPTION
## Summary

- Fixes 2 failing tests in `tests/test_description_service.py` introduced with the backfill history feature (#38)
- Both `test_returns_stripped_text_on_success` and `test_strips_trailing_period` were only patching `genai` but not `genai_types`; since `google-genai` isn't installed in CI, `genai_types` was `None`, causing `genai_types.GenerateContentConfig(...)` to raise `AttributeError` — silently caught and returning `None` instead of the mocked response

## Test plan

- [ ] `python3 -m pytest tests/test_description_service.py -v` — all 5 pass
- [ ] `python3 -m pytest tests/ -v` — 42/43 pass (1 remaining failure is pre-existing: `test_google_multi_image_requests_fail_fast` requires `google-genai` installed)

https://claude.ai/code/session_01NANo7DdF7u6Q9NbqGfBrbe